### PR TITLE
Nickname functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,22 @@ const server = http.createServer(app);
 app.use(express.static("./public"));
 
 const io = new Server(server);
-
+let users = {};
 io.on('connection',(socket)=>{
+
+    //assign default nickname
+    socket.nickname = `User${Math.floor(Math.random()*1000)}`;
+    users[socket.id] = socket.nickname;
+
+    //emit to all other users that someone has joined
+    io.emit('user joined',{user: socket.nickname, users: Object.values(users)});
+
+    socket.on('set nickname',(nickname)=>{
+        users[socket.id] = nickname;
+        socket.nickname = nickname;
+        io.emit('nickname changed',{id: socket.id, nickname});
+    })
+
     socket.on('chat message',(msg)=>{
         io.emit('chat message',msg);
     })

--- a/public/index.html
+++ b/public/index.html
@@ -17,14 +17,31 @@
   </head>
   <body>
     <ul id="messages"></ul>
+    <div id="messagesAlerts"></div>
     <form id="form" action="">
       <input id="input" autocomplete="off" /><button>Send</button>
+      <input type="text" id="nickname" placeholder="Enter a nickname"/>
+      <button id="setnickname" onClick="setNickname()">Set Nickname</button>
+      <br/>
     </form>
     <script src="/socket.io/socket.io.js"></script>
     <script>
       var socket = io();
+      
       var form = document.getElementById('form');
       var input = document.getElementById('input');
+
+      function setNickname() {
+        const nickname = document.getElementById('nickname').value;
+        socket.emit('set nickname',nickname);
+      }
+
+      //append message to the chat
+      function appendMessage(msg) {
+        const messageDiv = document.createElement('div');
+        messageDiv.textContent = msg;
+        document.getElementById('messagesAlerts').appendChild(messageDiv);
+      }
 
       form.addEventListener('submit', function(e){
         e.preventDefault();
@@ -39,6 +56,14 @@
         item.textContent = msg;
         messages.appendChild(item);
         window.scrollTo(0,document.body.scrollHeight);
+      })
+
+      socket.on('nickname changed',({id,nickname})=> {
+        appendMessage(`${nickname} is now as ${nickname}`);
+        const nicknameButton = document.getElementById('setnickname');
+        nicknameButton.disabled = true;
+        const nicknameField = document.getElementById('nickname')
+        nicknameField.disabled = true;
       })
     </script>
   </body>


### PR DESCRIPTION
fixes #1 
This PR introduces the ability for users to set and change their nicknames in the chat application. The main features added in this update include:

**1. Nickname Assignment:**

-   By default, a new user is assigned a random nickname (e.g., "User123"). Users can then set a custom nickname through the UI.
-   The server tracks nicknames for each connected client, ensuring messages are correctly attributed.

**2. Broadcast Nickname Changes:**  

-   When a user sets or changes their nickname, an update is broadcast to all connected users, notifying them of the nickname change.
-   This ensures that the chat room displays the correct and updated list of active users.

**3. User Experience Enhancements:**

- Nickname changes are reflected immediately in the chat, and a message is displayed indicating the updated name (e.g., "User123 is now known as Alice").
- The list of online users is kept up-to-date, showing the current nicknames for all active participants.